### PR TITLE
fix: react-redux example, `components/link.js`.

### DIFF
--- a/apps/react-redux/components/Link.js
+++ b/apps/react-redux/components/Link.js
@@ -3,7 +3,7 @@ import React, { PropTypes } from 'react';
 function Link(props) {
     const { name, params, options, router, navigateTo } = props;
 
-    const href = router.buildUrl(name);
+    const href = router.buildUrl(name, params);
     const onClick = () => navigateTo(name, params, options);
     const className = router.isActive(name, params) ? 'active' : '';
 


### PR DESCRIPTION
`router.buildUrl()` requires both the name and params to function properly.
